### PR TITLE
Adiciona usuário default na inicialização da API em ambiente dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ All decisions related with user requirements and needs are made on the design pr
   - TOKEN_SECRET={token-secret}
   - REFRESH_TOKEN_SECRET={refresh-token-secret}
 
+  - INIT_USER=alessauro
+  - INIT_PASSWORD=admin
+  - INIT_EMAIL=alessauro@mail
+
   - EMAIL_HOST={email-host}
   - EMAIL_PORT={email-port}
   - EMAIL_FROM={email-from}

--- a/backend/app.js
+++ b/backend/app.js
@@ -14,7 +14,6 @@ const mailRouter = require("./src/controllers/mail.controller");
 const subjectRouter = require("./src/controllers/subject.controller");
 const lessonRouter = require("./src/controllers/lesson.controller");
 
-
 const { handleError } = require("./src/helpers/error");
 
 const app = express();
@@ -36,9 +35,7 @@ const limiter = rateLimit({
 
 app.use(limiter);
 
-connectDb().then(() => {
-  console.log("Database connected");
-});
+connectDb();
 
 app.get(`${basePath}/ping`, (req, res) => {
   res.send("pong");
@@ -54,7 +51,7 @@ const routers = [
   lessonRouter,
 ];
 
-routers.forEach((router) => app.use(basePath, router));
+routers.forEach(router => app.use(basePath, router));
 
 app.use(errorLogger);
 

--- a/backend/src/mongo.js
+++ b/backend/src/mongo.js
@@ -1,5 +1,6 @@
 const mongoose = require("mongoose");
 const fs = require("fs");
+const User = require("./models/user");
 
 const {
   MONGO_INITDB_ROOT_USERNAME,
@@ -9,10 +10,11 @@ const {
   NODE_ENV,
 } = process.env;
 
+let isProduction = NODE_ENV === "production";
 let mongoURL;
 let DB_PASSWORD;
 
-if (NODE_ENV === "production") {
+if (isProduction) {
   DB_PASSWORD = fs.readFileSync(MONGO_INITDB_ROOT_PASSWORD, "utf-8");
 } else {
   DB_PASSWORD = MONGO_INITDB_ROOT_PASSWORD;
@@ -21,11 +23,32 @@ if (NODE_ENV === "production") {
 const mongoAuth = `${MONGO_INITDB_ROOT_USERNAME}:${DB_PASSWORD.trim()}`;
 mongoURL = `mongodb://${mongoAuth}@${MONGO_HOSTNAME}/${MONGO_DATABASE}`;
 
-const connectDB = () => {
-  return mongoose.connect(mongoURL, {
-    useNewUrlParser: true,
-    auth: { authSource: "admin" },
-  });
+const connectDB = async () => {
+  try {
+    await mongoose.connect(mongoURL, {
+      useNewUrlParser: true,
+      auth: { authSource: "admin" },
+    });
+
+    if (isProduction) {
+      console.log("Database connected");
+      return;
+    }
+
+    const { INIT_USER, INIT_EMAIL, INIT_PASSWORD } = process.env;
+
+    let user = {
+      name: INIT_USER,
+      email: INIT_EMAIL,
+      password: INIT_PASSWORD,
+    };
+    if (!User.findOne({ email: INIT_EMAIL })) {
+      await User.create(user);
+    }
+    console.log("Database connected with user:", user);
+  } catch (err) {
+    throw err;
+  }
 };
 
 module.exports = connectDB;


### PR DESCRIPTION
# Descrição

Este PR resolve a issue #62
Basicamente, após a conexão da API com o banco de dados, um `User` é criado (se já não existir e se não for ambiente `prod`)
Pra testar, basta

## Tipo da mudança

-  Nova feature
- Esta mudança requer um update da documentação (adiciona variáveis de ambiente)

# Como testar?

Basicamente, delete as pastas do banco de dados associadas aos `volumes` do `mongo`, crie as  variáveis de ambiente `INIT_USER`, `INIT_EMAIL`, `INIT_PASSWORD` em `.env/dev/app.env` e inicialize os serviços - `mongo` e `backend`. No log do `backend`, deve aparecer a mensagem de que a conexão com o banco foi feita e que o usuário default foi criado.
Pra testar, basta ou fazer login com o usuário pelo `Postman` ou fazer o login pela UI (serviço `frontend`)

Um outro caso de teste é subir o `backend` com `NODE_ENV == production`. Neste caso, o usuário default não deve ser criado automaticamente no banco.


# Checklist:

- Meu código segue as guidelines de estilo do projeto
- Fiz uma revisão própria do código

## Observação

Tentei inicialmente fazer um script para que o próprio banco já adicionasse o usuário ao inicializar. Porém tive um pouco de dificuldade pra fazer dessa maneira. Do jeito atual, qualquer mudança no código em ambiente `dev` causa uma nova query para verificar se o usuário já existe ou não. Não acho que vá influenciar na performance em ambiente `dev`, mas achei válido adicionar essa observação.