### PR TITLE
Fix da query para inicializar API com usuário default #62

### DIFF
--- a/backend/src/mongo.js
+++ b/backend/src/mongo.js
@@ -42,7 +42,8 @@ const connectDB = async () => {
       email: INIT_EMAIL,
       password: INIT_PASSWORD,
     };
-    if (!User.findOne({ email: INIT_EMAIL })) {
+    const query = await User.findOne({ email: INIT_EMAIL })
+    if (!query) {
       await User.create(user);
     }
     console.log("Database connected with user:", user);


### PR DESCRIPTION
## Tipo da mudança

- [x] Bug fix

# Descrição

Basicamente, na condição de verificar se o usuário já existe na conexão com o banco de dados, a query era sempre satisfeita pois não era o resultado da query que era visto, mas sim a _Promise_ da query. Portanto a query nunca era satisfeita e o usuário default nunca era criado.
Agora a query tem um `await`, o que faz com que na condição ela já esteja resolvida. Se retornar `null`, então cria o usuário com os dados que foram passados como variáveis de ambiente.
Este PR pode ser considerado um fix do PR #72.

# Como foi testado?
1. Foram adicionados os parâmetros abaixo no arquivo `.env/dev/app.env`
```
INIT_USER=alessauro
INIT_PASSWORD=admin
INIT_EMAIL=alessauro@mail
```

2. Os serviços, em especial a API, foram inicializados com `docker-compose up -d`
3. Depois pode ser verificado via Postman se o usuário realmente foi criado a partir do endpoint de Login em `Auth -> Login` na collection do Postman e ambiente `ales-dev`.
4. Se foi retornado código `200` e token de acesso, então o login foi feito com sucesso. Senão, provavelmente o usuário não foi criado.
5. Pra verificar os usuários do banco em ambiente `dev`, acesse o `localhost:8081` no navegador para ter acesso ao painel admin do Mongo DB. Acesse então o banco `ales` e a collection `users`.

# Checklist:

- [x] Fiz uma revisão própria do código