### PR TITLE
Integra edição e remoção de aulas

### DIFF
--- a/backend/src/services/lesson.service.js
+++ b/backend/src/services/lesson.service.js
@@ -8,7 +8,7 @@ const getLessonsByCourseId = async courseId => {
 };
 
 const getLessonById = async id => {
-  return await Lesson.findById(id);
+  return await Lesson.findById(id).populate('professors');
 };
 
 const createLesson = async data => {

--- a/frontend/src/routes/router.js
+++ b/frontend/src/routes/router.js
@@ -28,6 +28,7 @@ import CourseEdit from "views/Course/CourseEdit/CourseEdit";
 import Quarantine from "views/Quarantine/Quarantine";
 
 import LessonNew from "views/Lesson/LessonNew/LessonNew";
+import LessonEdit from "views/Lesson/LessonEdit/LessonEdit";
 
 const router = (
   <Switch>
@@ -48,6 +49,7 @@ const router = (
     <PrivateRoute path={routes.PROFESSORS} component={ProfessorList} />
 
     <PrivateRoute path={routes.LESSON_NEW} component={LessonNew} />
+    <PrivateRoute path={routes.LESSON_EDIT} component={LessonEdit} />
 
     <PrivateRoute path={routes.COURSE_EDIT} component={CourseEdit} />
     <PrivateRoute path={routes.COURSE_NEW} component={CourseNew} />

--- a/frontend/src/routes/routes.js
+++ b/frontend/src/routes/routes.js
@@ -22,7 +22,8 @@ const routes = {
   COURSE_EDIT: "/courses/:id/edit",
   QUARANTINE: "/quarentenales",
 
-  LESSON_NEW: "/:id/lessons/new"
+  LESSON_NEW: "/:id/lessons/new",
+  LESSON_EDIT: "/:id/lessons/:lesson_id"
 };
 
 export default routes;

--- a/frontend/src/services/lesson.service.js
+++ b/frontend/src/services/lesson.service.js
@@ -7,3 +7,7 @@ export const create = async (data) => {
 export const get = async (id) => {
     return await api.get(`/lessons/${id}`);
 }
+
+export const update = async (id, data) => {
+    return await api.put(`/lessons/${id}`, data)
+}

--- a/frontend/src/services/lesson.service.js
+++ b/frontend/src/services/lesson.service.js
@@ -3,3 +3,7 @@ import api from "./api";
 export const create = async (data) => {
     return await api.post("/lessons", data);
 };
+
+export const get = async (id) => {
+    return await api.get(`/lessons/${id}`);
+}

--- a/frontend/src/services/lesson.service.js
+++ b/frontend/src/services/lesson.service.js
@@ -9,5 +9,9 @@ export const get = async (id) => {
 }
 
 export const update = async (id, data) => {
-    return await api.put(`/lessons/${id}`, data)
+    return await api.put(`/lessons/${id}`, data);
+}
+
+export const remove = async (id) => {
+    return await api.delete(`/lessons/${id}`);
 }

--- a/frontend/src/views/Course/CourseDetail/CourseDetail.js
+++ b/frontend/src/views/Course/CourseDetail/CourseDetail.js
@@ -177,8 +177,8 @@ const CourseDetail = ({ history, match }) => {
                             </div>
                             <div className={styles.lesson__actions}>
                               <div className={styles.buttons}>
-                                <Button text="Detalhes" kind="success" />
-                                <Button text="Editar" kind="primary" />
+                                <Button text="Editar" kind="primary" onClick={() => history.push(routes.LESSON_EDIT.replace(":id", id).replace(":lesson_id", lesson._id))} />
+                                <Button text="Deletar" kind="danger" />
                               </div>
                             </div>
                           </div>

--- a/frontend/src/views/Course/CourseDetail/CourseDetail.js
+++ b/frontend/src/views/Course/CourseDetail/CourseDetail.js
@@ -175,6 +175,12 @@ const CourseDetail = ({ history, match }) => {
                                 })}
                               </div>
                             </div>
+                            <div className={styles.lesson__actions}>
+                              <div className={styles.buttons}>
+                                <Button text="Detalhes" kind="success" />
+                                <Button text="Editar" kind="primary" />
+                              </div>
+                            </div>
                           </div>
                         </Accordion>
                       )

--- a/frontend/src/views/Course/CourseDetail/CourseDetail.js
+++ b/frontend/src/views/Course/CourseDetail/CourseDetail.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 
-import { get, remove } from "services/course.service";
+import { get, remove as removeCourse } from "services/course.service";
+import { remove as removeLesson } from "services/lesson.service";
 
 import { formatDateToReceive } from "helpers/masks";
 
@@ -31,74 +32,114 @@ const CourseDetail = ({ history, match }) => {
   const [lessons, setLessons] = useState([]);
 
   const [isLoading, setIsLoading] = useState(false);
-  const [isDeleting, setIsDeleting] = useState(false);
-  const [modalIsOpen, setModalIsOpen] = useState(false);
+  const [isDeletingCourse, setisDeletingCourse] = useState(false);
+  const [isDeletingLesson, setisDeletingLesson] = useState(false);
+  const [deleteCourseModal, setDeleteCourseModal] = useState(false);
+  const [deleteLessonModal, setDeleteLessonModal] = useState(false);
+  const [lessonToBeDeleted, setLessonToBeDeleted] = useState(null);
+
+  const getCourse = (course_id) => {
+    setIsLoading(true);
+    get(course_id)
+      .then((response) => {
+        const {
+          name,
+          description,
+          beginningDate,
+          endDate,
+          professors,
+          coordinator,
+        } = response.data.course;
+        const { lessons } = response.data;
+        setName(name);
+        setDescription(description);
+        setBeginningDate(formatDateToReceive(beginningDate));
+        setEndDate(formatDateToReceive(endDate));
+        setProfessors(professors);
+        setCoordinator(coordinator);
+        setLessons(lessons);
+      })
+      .catch((err) => {
+        if (err.response && err.response.status !== 401) {
+          toast.error("Ops! Aconteceu algum erro para retornar os dados");
+        }
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }
 
   useEffect(() => {
-    const getCourse = (id) => {
-      setIsLoading(true);
-      get(id)
-        .then((response) => {
-          const {
-            name,
-            description,
-            beginningDate,
-            endDate,
-            professors,
-            coordinator,
-          } = response.data.course;
-          const { lessons } = response.data;
-          setName(name);
-          setDescription(description);
-          setBeginningDate(formatDateToReceive(beginningDate));
-          setEndDate(formatDateToReceive(endDate));
-          setProfessors(professors);
-          setCoordinator(coordinator);
-          setLessons(lessons);
-        })
-        .catch((err) => {
-          if (err.response && err.response.status !== 401) {
-            toast.error("Ops! Aconteceu algum erro para retornar os dados");
-          }
-        })
-        .finally(() => {
-          setIsLoading(false);
-        });
-    };
     getCourse(id);
   }, []);
 
-  const deleteCourse = (id) => {
-    setIsDeleting(true);
+  const deleteCourse = (course_id) => {
+    setisDeletingCourse(true);
 
-    remove(id)
+    removeCourse(course_id)
       .then(() => {
         history.push(routes.COURSES);
         toast.success("Matéria removida!");
       })
       .catch(() => {
         toast.error("Ops! Aconteceu algum erro para deletar a matéria");
-        setIsDeleting(false);
+        setisDeletingCourse(false);
       });
   };
 
+  const deleteLesson = (course_id, lesson) => {
+    setisDeletingLesson(true);
+
+    removeLesson(lesson._id)
+      .then(() => {
+        getCourse(course_id)
+      })
+      .catch(() => {
+        toast.error("Ops! Aconteceu algum erro para deletar a aula");
+      })
+      .finally(() => {
+        setisDeletingLesson(false);
+        setDeleteLessonModal(false);
+      })
+  }
+
   return (
     <Page>
-      {modalIsOpen && (
+      {deleteCourseModal && (
         <div className={styles.modal}>
           <Modal
             title="Tem certeza que deseja deletar a matéria?"
-            onClose={() => setModalIsOpen(false)}
+            onClose={() => setDeleteCourseModal(false)}
           >
             <div className={styles.modal__buttons}>
-              <Button text="Cancelar" onClick={() => setModalIsOpen(false)} />
+              <Button text="Cancelar" onClick={() => setDeleteCourseModal(false)} />
               <Button
                 text="Deletar"
                 kind="danger"
                 width={120}
                 onClick={() => deleteCourse(id)}
-                isLoading={isDeleting}
-                disabled={isDeleting}
+                isLoading={isDeletingCourse}
+                disabled={isDeletingCourse}
+              />
+            </div>
+          </Modal>
+        </div>
+      )}
+      {deleteLessonModal && (
+        <div className={styles.modal}>
+          <Modal
+            title="Tem certeza que deseja deletar a aula?"
+            onClose={() => setDeleteLessonModal(false)}
+          >
+            <div className={styles.modal__buttons}>
+              <Button text="Cancelar" onClick={() => setDeleteLessonModal(false)} />
+              <Button
+                text="Deletar"
+                kind="danger"
+                width={120}
+                onClick={() => deleteLesson(id, lessonToBeDeleted)}
+                isLoading={isDeletingLesson}
+                disabled={isDeletingLesson}
               />
             </div>
           </Modal>
@@ -178,7 +219,12 @@ const CourseDetail = ({ history, match }) => {
                             <div className={styles.lesson__actions}>
                               <div className={styles.buttons}>
                                 <Button text="Editar" kind="primary" onClick={() => history.push(routes.LESSON_EDIT.replace(":id", id).replace(":lesson_id", lesson._id))} />
-                                <Button text="Deletar" kind="danger" />
+                                <Button text="Deletar" kind="danger" onClick={() => {
+                                  setLessonToBeDeleted(lesson);
+                                  setDeleteLessonModal(true);
+                                  window.scrollTo({ top: 200, behavior: "smooth" })
+                                }}
+                                />
                               </div>
                             </div>
                           </div>
@@ -196,7 +242,7 @@ const CourseDetail = ({ history, match }) => {
                     kind="primary"
                     onClick={() => history.push(routes.COURSE_EDIT.replace(":id", id))}
                   />
-                  <Button text="Deletar" kind="danger" onClick={() => setModalIsOpen(true)} />
+                  <Button text="Deletar" kind="danger" onClick={() => { setDeleteCourseModal(true); window.scrollTo({ top: 200, behavior: "smooth" }) }} />
                 </div>
               </div>
             </Container>

--- a/frontend/src/views/Course/CourseDetail/CourseDetail.module.scss
+++ b/frontend/src/views/Course/CourseDetail/CourseDetail.module.scss
@@ -134,6 +134,20 @@
             flex-wrap: wrap;
           }
         }
+
+        &__actions {
+          margin-top: var(--spacing-large);
+
+          .buttons {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+
+            @include tablet-portrait {
+              flex-direction: row;
+            }
+          }
+        }
       }
     }
   }

--- a/frontend/src/views/Lesson/LessonEdit/LessonEdit.js
+++ b/frontend/src/views/Lesson/LessonEdit/LessonEdit.js
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from "react";
 
-import routes from "routes/routes";
 import { get as getLesson, update } from "services/lesson.service";
 import { get as getCourse } from "services/course.service";
 
@@ -100,7 +99,7 @@ const LessonEdit = ({ history, match }) => {
 
     update(lesson_id, data)
       .then(() => {
-        history.push(routes.COURSE_DETAIL.replace(":id", course_id));
+        history.goBack();
         toast.success("Aula atualizada!");
       })
       .catch(() => {

--- a/frontend/src/views/Lesson/LessonEdit/LessonEdit.js
+++ b/frontend/src/views/Lesson/LessonEdit/LessonEdit.js
@@ -1,0 +1,148 @@
+import React, { useState, useEffect } from "react";
+
+import { get as getLesson } from "services/lesson.service";
+import { get as getCourse } from "services/course.service";
+
+import parseDropdownOptions from "helpers/dropdown";
+
+import { toast } from "react-toastify";
+
+import Page from "components/Page/Page";
+import PageTitle from "components/PageTitle/PageTitle";
+import Container from "components/Container/Container";
+import Loader from "components/Loader/Loader";
+import Input from "components/Input/Input";
+import TextArea from "components/TextArea/TextArea";
+import DateInput from "components/DateInput/DateInput";
+import Dropdown from "components/Dropdown/Dropdown";
+import Chip from "components/Chip/Chip";
+
+import styles from "./LessonEdit.module.scss";
+
+const LessonEdit = ({ match }) => {
+
+  const course_id = match.params.id
+  const { lesson_id } = match.params
+
+  const [title, setTitle] = useState("")
+  const [description, setDescription] = useState("");
+  const [date, setDate] = useState(null);
+  const [allocatedProfessors, setAllocatedProfessors] = useState([]);
+  const [professors, setProfessors] = useState([]);
+
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    setIsLoading(true);
+    getLesson(lesson_id)
+      .then((response) => {
+        const { lesson } = response.data;
+        setTitle(lesson.title)
+        setDescription(lesson.description)
+        setDate(new Date(lesson.date))
+        setAllocatedProfessors(lesson.professors)
+      })
+      .catch(() => {
+        toast.error("Ops! Aconteceu algum erro para carregar os dados da aula");
+      })
+      .finally(() => {
+        setIsLoading(false);
+      })
+  }, []);
+
+  useEffect(() => {
+    setIsLoading(true);
+    getCourse(course_id)
+      .then((response) => {
+        const { course } = response.data;
+        setProfessors(course.professors);
+      })
+      .catch((err) => {
+        if (err.response && err.response.status !== 401) {
+          toast.error("Ops! Aconteceu algum erro para retornar os dados");
+        }
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }, []);
+
+  const addProfessor = (id, professors, allocatedProfessors) => {
+    const professor = professors.find((prof) => prof._id === id);
+
+    if (!allocatedProfessors.find((prof) => prof._id === id))
+      setAllocatedProfessors((state) => [...state, professor]);
+    return;
+  };
+
+  const removeProfessor = (name) => {
+    const updatedProfessors = allocatedProfessors.filter((prof) => prof.name !== name);
+    setAllocatedProfessors(updatedProfessors);
+  };
+
+  return (
+    <Page>
+      <PageTitle title="Editar Aula" icon="fas fa-edit" />
+      <Container>
+        <div className={styles.container}>
+          {isLoading ? <div className="loader">
+            <Loader />
+          </div> : (
+              <form className={styles.form}>
+                <div className={styles.section}>
+                  <Input
+                    placeholder="Título"
+                    type="text"
+                    onChange={(e) => setTitle(e.target.value)}
+                    value={title}
+                    required
+                  />
+                </div>
+                <div className={styles.section}>
+                  <TextArea
+                    placeholder="Descrição"
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    rows={4}
+                    required
+                  />
+                </div>
+                <div className={styles.section}>
+                  <DateInput
+                    placeholder="Data"
+                    selected={date}
+                    onChange={(date) => setDate(date)}
+                    required
+                  />
+                </div>
+                <div className={styles.section}>
+                  <div className={styles.dropdown}>
+                    <Dropdown
+                      name="coordinator"
+                      options={parseDropdownOptions("_id", "name", professors)}
+                      onSelect={(prof) => addProfessor(prof, professors, allocatedProfessors)}
+                      label="Professores"
+                    />
+                  </div>
+                  <div className={styles.allocatedProfessors}>
+                    {allocatedProfessors.map(prof => {
+                      return (
+                        <Chip
+                          text={prof.name}
+                          key={prof._id}
+                          removable
+                          onRemove={removeProfessor}
+                        />
+                      )
+                    })}
+                  </div>
+                </div>
+              </form>
+            )}
+        </div>
+      </Container>
+    </Page>
+  )
+}
+
+export default LessonEdit;

--- a/frontend/src/views/Lesson/LessonEdit/LessonEdit.module.scss
+++ b/frontend/src/views/Lesson/LessonEdit/LessonEdit.module.scss
@@ -22,5 +22,21 @@
         flex-wrap: wrap;
       }
     }
+
+    .buttons {
+      display: flex;
+      justify-content: center;
+      margin: var(--spacing-large) 0;
+
+      button {
+        &:first-of-type {
+          margin-right: var(--spacing-huge);
+        }
+
+        &:last-of-type {
+          width: 160px;
+        }
+      }
+    }
   }
 }

--- a/frontend/src/views/Lesson/LessonEdit/LessonEdit.module.scss
+++ b/frontend/src/views/Lesson/LessonEdit/LessonEdit.module.scss
@@ -1,0 +1,26 @@
+@import "~styles/breakpoints";
+
+.container {
+  color: var(--gray-dark);
+  margin: auto;
+
+  .form {
+    margin: auto;
+    max-width: 400px;
+
+    .section {
+      margin: var(--spacing-huge) 0;
+
+      .dropdown {
+        margin: var(--spacing-large) auto;
+        max-width: 300px;
+      }
+
+      .allocatedProfessors {
+        display: flex;
+        justify-content: center;
+        flex-wrap: wrap;
+      }
+    }
+  }
+}

--- a/frontend/src/views/Lesson/LessonNew/LessonNew.js
+++ b/frontend/src/views/Lesson/LessonNew/LessonNew.js
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from "react";
 
-import routes from "routes/routes";
 import { list } from "services/professor.service";
 import { create } from "services/lesson.service";
 
@@ -84,7 +83,7 @@ const LessonNew = ({ history, match }) => {
 
     create(data)
       .then(() => {
-        history.push(routes.COURSE_DETAIL.replace(":id", course_id));
+        history.goBack();
         toast.success("Aula adicionada!");
       })
       .catch(() => {

--- a/frontend/src/views/Lesson/LessonNew/LessonNew.js
+++ b/frontend/src/views/Lesson/LessonNew/LessonNew.js
@@ -72,7 +72,9 @@ const LessonNew = ({ history, match }) => {
     setIsSubmitting(true);
 
     const { date } = data;
-    data.date = await date.toISOString();
+    if (date) {
+      data.date = await date.toISOString();
+    }
 
     /* change names for id's */
     const { professors } = data;
@@ -125,7 +127,6 @@ const LessonNew = ({ history, match }) => {
                     placeholder="Data"
                     selected={date}
                     onChange={(date) => setDate(date)}
-                    required
                   />
                 </div>
                 <div className={styles.section}>


### PR DESCRIPTION
## Tipo da mudança
- [x] Nova feature

# Descrição
- Integração da edição de aulas de uma matéria
- Integração da remoção de aula de uma matéria
- Define campo `date` de uma aula como opcional ao invés de obrigatório

![image](https://user-images.githubusercontent.com/32711358/104854243-53ffe880-58e4-11eb-935c-ebcec8a5c5e4.png)
![image](https://user-images.githubusercontent.com/32711358/104854254-64b05e80-58e4-11eb-9364-c8536d97138b.png)
![image](https://user-images.githubusercontent.com/32711358/104854259-73971100-58e4-11eb-9152-3eba73c590ad.png)


# Como foi testado?
Dada uma matéria, adicione aulas para testar as funcionalidades de edição e remoção.
A edição é feita numa nova tela e após ter sido feita, o usuário deve ser redirecionado de volta pra tela de detalhe da matéria.
A remoção é feita na própria tela de detalhe de matéria. Ao clicar em `Deletar` matéria, um modal deve ser aberto para a confirmação da ação. Após a confirmação, é feita uma nova requisição dos dados da matéria que por sua vez são renderizados novamente, agora sem a matéria removida (em caso de sucesso).

# Checklist:

- [x] Fiz uma revisão própria do código
