### PR TITLE
Adiciona testes para os controllers da API #76

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -2,5 +2,6 @@ module.exports = {
   clearMocks: true,
   coverageDirectory: "coverage",
   testEnvironment: "node",
-  testTimeout: 10000
+  testTimeout: 10000,
+  testMatch: ["**/__tests__/**/*.js", "**/?(*.)+(_spec|_test).js"]
 };

--- a/backend/package.json
+++ b/backend/package.json
@@ -31,6 +31,7 @@
     "eslint-plugin-import": "^2.22.0",
     "jest": "^26.4.2",
     "sinon": "^9.2.3",
+    "supertest": "^6.0.1",
     "nodemon": "^2.0.2"
   }
 }

--- a/backend/src/controllers/__tests__/auth.controller.test.js
+++ b/backend/src/controllers/__tests__/auth.controller.test.js
@@ -1,0 +1,98 @@
+const request = require("supertest");
+const mongoose = require("mongoose");
+
+const AuthController = require("../auth.controller");
+
+const { createServer, createAgent, login } = require("../../helpers/test");
+const connect = require("../../mongo");
+const User = require("../../models/user");
+
+const app = createServer();
+connect("auth_controller_test");
+
+describe("Auth controller test", () => {
+
+  const authUser = createAgent(app);
+
+  beforeAll(async (done) => {
+    await User.deleteMany({});
+    login(authUser, done);
+  });
+
+  afterEach(async () => {
+    await User.deleteMany({});
+  })
+
+  afterAll(async () => {
+    await mongoose.connection.close();
+  });
+
+  it("has a module", () => {
+    expect(AuthController).toBeDefined();
+  });
+
+  describe("auth controllers test", () => {
+    it("tries to log in without an email", async () => {
+      await request(app)
+        .post("/api/auth/login")
+        .send({ password: "foobar" })
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to log in without a password", async () => {
+      await request(app)
+        .post("/api/auth/login")
+        .send({ email: "foo@mail" })
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to log in without a password", async () => {
+      await request(app)
+        .post("/api/auth/login")
+        .send({ email: "foo@mail" })
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to log in with invalid credentials", async () => {
+      const { email } = await User.create({ email: "foo@mail", password: "foobar" });
+      await request(app)
+        .post("/api/auth/login")
+        .send({ email, password: "foo_bar" })
+        .expect('Content-Type', /json/)
+        .expect(401);
+    });
+
+    it("can log in", async () => {
+      const { email } = await User.create({ email: "foo@mail", password: "foobar" });
+      await request(app)
+        .post("/api/auth/login")
+        .send({ email, password: "foobar" })
+        .expect('Content-Type', /json/)
+        .expect(200);
+    });
+
+    it("can refresh jwt", async () => {
+      await authUser
+        .post("/api/auth/refresh-token")
+        .expect('Content-Type', /json/)
+        .expect(200);
+    });
+
+    it("can logout", async () => {
+      await authUser
+        .post("/api/auth/logout")
+        .expect('Content-Type', /json/)
+        .expect(202);
+    });
+
+    it("is unauthorized to get me", async () => {
+      await request(app)
+        .get("/api/auth/me")
+        .expect('Content-Type', /json/)
+        .expect(401);
+    });
+  });
+});

--- a/backend/src/controllers/__tests__/course.controller.test.js
+++ b/backend/src/controllers/__tests__/course.controller.test.js
@@ -1,0 +1,250 @@
+const request = require("supertest");
+const mongoose = require("mongoose");
+
+const Course = require("../../models/course");
+const Professor = require("../../models/professor");
+const CourseController = require("../course.controller");
+
+const { createServer, createAgent, login } = require("../../helpers/test");
+const connect = require("../../mongo");
+
+const app = createServer();
+connect("course_controller_test");
+
+describe("Course controller test", () => {
+
+  const authUser = createAgent(app);
+
+  beforeAll(async (done) => {
+    await Course.deleteMany({});
+    login(authUser, done);
+  });
+
+  afterEach(async () => {
+    await Course.deleteMany({});
+    await Professor.deleteMany({});
+  });
+
+  afterAll(async () => {
+    await mongoose.connection.close();
+  });
+
+  it("has a module", () => {
+    expect(CourseController).toBeDefined();
+  });
+
+  describe("course controllers test", () => {
+    it("can list courses", async () => {
+      await request(app)
+        .get("/api/courses")
+        .expect('Content-Type', /json/)
+        .expect(200);
+    });
+
+    it("tries to get a non existent course", async () => {
+      const { _id } = await Course.create({ name: "math" });
+      await Course.deleteOne({ name: "math" });
+      await request(app)
+        .get(`/api/courses/${_id}`)
+        .expect('Content-Type', /json/)
+        .expect(404);
+    });
+
+    it("can get a course", async () => {
+      const { _id } = await Course.create({ name: "math" });
+      await request(app)
+        .get(`/api/courses/${_id}`)
+        .expect('Content-Type', /json/)
+        .expect(200);
+    });
+
+    it("is unauthorized to delete a course", async () => {
+      const { _id } = await Course.create({ name: "math" });
+      await request(app)
+        .delete(`/api/courses/${_id}`)
+        .expect('Content-Type', /json/)
+        .expect(401);
+    });
+
+    it("tries to delete a non existent course", async () => {
+      const { _id } = await Course.create({ name: "math" });
+      await Course.deleteOne({ name: "math" });
+      await authUser
+        .delete(`/api/courses/${_id}`)
+        .expect('Content-Type', /json/)
+        .expect(404);
+    });
+
+    it("can delete a course", async () => {
+      const { _id } = await Course.create({ name: "math" });
+      await authUser
+        .delete(`/api/courses/${_id}`)
+        .expect('Content-Type', /json/)
+        .expect(202);
+    });
+
+    it("is unauthorized to create a course", async () => {
+      const course = { name: "math", description: "very good" };
+      await request(app)
+        .post("/api/courses")
+        .send(course)
+        .expect('Content-Type', /json/)
+        .expect(401);
+    });
+
+    it("tries to create a course without a name", async () => {
+      const { _id } = await Professor.create({ name: "foo", email: "foo@mail" });
+      const course = {
+        beginningDate: Date.now(),
+        endDate: Date.now(),
+        coordinator: _id,
+        professors: [_id]
+      };
+      await authUser
+        .post("/api/courses")
+        .send(course)
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to create a course without a beginningDate", async () => {
+      const { _id } = await Professor.create({ name: "foo", email: "foo@mail" });
+      const course = {
+        name: "math",
+        endDate: Date.now(),
+        coordinator: _id,
+        professors: [_id]
+      };
+      await authUser
+        .post("/api/courses")
+        .send(course)
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to create a course without a endDate", async () => {
+      const { _id } = await Professor.create({ name: "foo", email: "foo@mail" });
+      const course = {
+        name: "math",
+        beginningDate: Date.now(),
+        coordinator: _id,
+        professors: [_id]
+      };
+      await authUser
+        .post("/api/courses")
+        .send(course)
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to create a course without a coordinator", async () => {
+      const { _id } = await Professor.create({ name: "foo", email: "foo@mail" });
+      const course = {
+        name: "math",
+        beginningDate: Date.now(),
+        endDate: Date.now(),
+        professors: [_id]
+      };
+      await authUser
+        .post("/api/courses")
+        .send(course)
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to create a course without professors", async () => {
+      const { _id } = await Professor.create({ name: "foo", email: "foo@mail" });
+      const course = {
+        name: "math",
+        beginningDate: Date.now(),
+        endDate: Date.now(),
+        coordinator: _id
+      };
+      await authUser
+        .post("/api/courses")
+        .send(course)
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("can create a course", async () => {
+      const { _id } = await Professor.create({ name: "foo", email: "foo@mail" });
+      const course = {
+        name: "math",
+        beginningDate: Date.now(),
+        endDate: Date.now(),
+        coordinator: _id,
+        professors: [_id]
+      };
+      await authUser
+        .post("/api/courses")
+        .send(course)
+        .expect('Content-Type', /json/)
+        .expect(201);
+    });
+
+    it("is unauthorized to update a course", async () => {
+      const course = await Course.create({ name: "math" });
+      await request(app)
+        .put(`/api/courses/${course._id}`)
+        .send({ description: "very good" })
+        .expect('Content-Type', /json/)
+        .expect(401);
+    });
+
+    it("can update a course", async () => {
+      const course = await Course.create({ name: "math" });
+      await authUser
+        .put(`/api/courses/${course._id}`)
+        .send({ description: "very good" })
+        .expect('Content-Type', /json/)
+        .expect(200);
+    });
+
+    it("is unauthorized to add a lesson", async () => {
+      const course = await Course.create({ name: "math" });
+      await request(app)
+        .post(`/api/courses/${course._id}/lessons`)
+        .send({ title: "lesson 1", description: "introduction" })
+        .expect('Content-Type', /json/)
+        .expect(401);
+    });
+
+    it("tries to add a lesson without a title", async () => {
+      const course = await Course.create({ name: "math" });
+      await authUser
+        .post(`/api/courses/${course._id}/lessons`)
+        .send({ description: "introduction" })
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to add a lesson without a description", async () => {
+      const course = await Course.create({ name: "math" });
+      await authUser
+        .post(`/api/courses/${course._id}/lessons`)
+        .send({ title: "lesson 1" })
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to add a lesson to a non existent course", async () => {
+      const course = await Course.create({ name: "math" });
+      await Course.deleteOne({ name: "math" })
+      await authUser
+        .post(`/api/courses/${course._id}/lessons`)
+        .send({ title: "lesson 1", description: "introduction" })
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("can add a lesson to a course", async () => {
+      const course = await Course.create({ name: "math" });
+      await authUser
+        .post(`/api/courses/${course._id}/lessons`)
+        .send({ title: "lesson 1", description: "introduction" })
+        .expect('Content-Type', /json/)
+        .expect(201);
+    });
+  });
+});

--- a/backend/src/controllers/__tests__/lesson.controller.test.js
+++ b/backend/src/controllers/__tests__/lesson.controller.test.js
@@ -1,0 +1,113 @@
+const request = require("supertest");
+const mongoose = require("mongoose");
+
+const Lesson = require("../../models/lesson");
+const LessonController = require("../lesson.controller");
+
+const { createServer, createAgent, login } = require("../../helpers/test");
+const connect = require("../../mongo");
+
+const app = createServer();
+connect("lesson_controller_test");
+
+describe("Lesson controller test", () => {
+
+  const authUser = createAgent(app);
+
+  beforeAll(async (done) => {
+    await Lesson.deleteMany({});
+    login(authUser, done);
+  });
+
+  afterEach(async () => {
+    await Lesson.deleteMany({});
+  });
+
+  afterAll(async () => {
+    await mongoose.connection.close();
+  });
+
+  it("has a module", () => {
+    expect(LessonController).toBeDefined();
+  });
+
+  describe("lesson controllers test", () => {
+    it("is unauthorized to get a lesson", async () => {
+      const { _id } = await Lesson.create({ title: "lesson 1", description: "introduction" });
+      await request(app)
+        .get(`/api/lessons/${_id}`)
+        .expect('Content-Type', /json/)
+        .expect(401);
+    });
+
+    it("tries to get a non existent lesson", async () => {
+      const { _id } = await Lesson.create({ title: "lesson 1", description: "introduction" });
+      await Lesson.deleteOne({ _id });
+      await authUser
+        .get(`/api/lessons/${_id}`)
+        .expect('Content-Type', /json/)
+        .expect(404);
+    });
+
+    it("can get a lesson", async () => {
+      const { _id } = await Lesson.create({ title: "lesson 1", description: "introduction" });
+      await authUser
+        .get(`/api/lessons/${_id}`)
+        .expect('Content-Type', /json/)
+        .expect(200);
+    });
+
+    it("is unauthorized to update a lesson", async () => {
+      const { _id } = await Lesson.create({ title: "lesson 1", description: "introduction" });
+      await request(app)
+        .put(`/api/lessons/${_id}`)
+        .send({ description: "closing class" })
+        .expect('Content-Type', /json/)
+        .expect(401);
+    });
+
+    it("tries to update a non existent lesson", async () => {
+      const { _id } = await Lesson.create({ title: "lesson 1", description: "introduction" });
+      await Lesson.deleteOne({ _id });
+      await authUser
+        .put(`/api/lessons/${_id}`)
+        .send({ description: "closing class" })
+        .expect('Content-Type', /json/)
+        .expect(404);
+    });
+
+    it("can update a lesson", async () => {
+      const { _id } = await Lesson.create({ title: "lesson 1", description: "introduction" });
+      await authUser
+        .put(`/api/lessons/${_id}`)
+        .send({ description: "closing class" })
+        .expect('Content-Type', /json/)
+        .expect(200);
+    });
+
+    it("is unauthorized to delete a lesson", async () => {
+      const { _id } = await Lesson.create({ title: "lesson 1", description: "introduction" });
+      await request(app)
+        .delete(`/api/lessons/${_id}`)
+        .expect('Content-Type', /json/)
+        .expect(401);
+    });
+
+    it("tries to delete a non existent lesson", async () => {
+      const { _id } = await Lesson.create({ title: "lesson 1", description: "introduction" });
+      await Lesson.deleteOne({ _id });
+      await authUser
+        .delete(`/api/lessons/${_id}`)
+        .expect('Content-Type', /json/)
+        .expect(404);
+    });
+
+    it("can delete a lesson", async () => {
+      const { _id } = await Lesson.create({ title: "lesson 1", description: "introduction" });
+      await authUser
+        .delete(`/api/lessons/${_id}`)
+        .expect('Content-Type', /json/)
+        .expect(202);
+    });
+  });
+});

--- a/backend/src/controllers/__tests__/mail.controller.test.js
+++ b/backend/src/controllers/__tests__/mail.controller.test.js
@@ -1,0 +1,61 @@
+const request = require("supertest");
+const mongoose = require("mongoose");
+
+const MailController = require("../mail.controller");
+
+const { createServer, createAgent, login } = require("../../helpers/test");
+const connect = require("../../mongo");
+
+const app = createServer();
+connect("mail_controller_test");
+
+describe("Mail controller test", () => {
+
+  const authUser = createAgent(app);
+
+  beforeAll(async (done) => {
+    login(authUser, done);
+  });
+
+  afterAll(async () => {
+    await mongoose.connection.close();
+  });
+
+  it("has a module", () => {
+    expect(MailController).toBeDefined();
+  });
+
+  describe("mail controllers test", () => {
+    it("tries to send an email without a name", async () => {
+      await request(app)
+        .post("/api/mail")
+        .send({ email: "foo@mail", message: "foo bar" })
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to send an email without an email", async () => {
+      await request(app)
+        .post("/api/mail")
+        .send({ name: "foo", message: "foo bar" })
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to send an email without a message", async () => {
+      await request(app)
+        .post("/api/mail")
+        .send({ name: "foo", email: "foo@mail" })
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("can send an email", async () => {
+      await request(app)
+        .post("/api/mail")
+        .send({ name: "foo", email: "foo@mail", message: "foo bar" })
+        .expect('Content-Type', /json/)
+        .expect(200);
+    });
+  });
+});

--- a/backend/src/controllers/__tests__/password.controller.test.js
+++ b/backend/src/controllers/__tests__/password.controller.test.js
@@ -1,0 +1,242 @@
+const request = require("supertest");
+const mongoose = require("mongoose");
+
+const User = require("../../models/user");
+const PasswordController = require("../password.controller");
+
+const { createServer, createAgent, login } = require("../../helpers/test");
+const connect = require("../../mongo");
+
+const app = createServer();
+connect("password_controller_test");
+
+describe("Password controller test", () => {
+
+  const authUser = createAgent(app);
+
+  beforeAll(async (done) => {
+    await User.deleteMany({});
+    login(authUser, done);
+  });
+
+  afterEach(async () => {
+    await User.deleteMany({});
+  });
+
+  afterAll(async () => {
+    await mongoose.connection.close();
+  });
+
+  it("has a module", () => {
+    expect(PasswordController).toBeDefined();
+  });
+
+  describe("password controllers test", () => {
+    it("is unauthorized to update password", async () => {
+      const { _id } = await User.create({ email: "foo@mail", password: "foobar" });
+      await request(app)
+        .post(`/api/password/update/${_id}`)
+        .send({ password: "foobar", new_password: "foo_bar", new_password_conf: "foo_bar" })
+        .expect('Content-Type', /json/)
+        .expect(401);
+    });
+
+    it("tries to update password without passing the current one", async () => {
+      const { _id } = await User.create({ email: "foo@mail", password: "foobar" });
+      await authUser
+        .post(`/api/password/update/${_id}`)
+        .send({ new_password: "foo_bar", new_password_conf: "foo_bar" })
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to update password without the new one", async () => {
+      const { _id } = await User.create({ email: "foo@mail", password: "foobar" });
+      await authUser
+        .post(`/api/password/update/${_id}`)
+        .send({ password: "foobar", new_password_conf: "foo_bar" })
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to update password without the new password's confirmation", async () => {
+      const { _id } = await User.create({ email: "foo@mail", password: "foobar" });
+      await authUser
+        .post(`/api/password/update/${_id}`)
+        .send({ password: "foobar", new_password: "foo_bar" })
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to update password with new password's length < 5", async () => {
+      const { _id } = await User.create({ email: "foo@mail", password: "foobar" });
+      await authUser
+        .post(`/api/password/update/${_id}`)
+        .send({ password: "foobar", new_password: "bar", new_password_conf: "bar" })
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to update password with new password and its confirmation being differents", async () => {
+      const { _id } = await User.create({ email: "foo@mail", password: "foobar" });
+      await authUser
+        .post(`/api/password/update/${_id}`)
+        .send({ password: "foobar", new_password: "foo_bar", new_password_conf: "foo__bar" })
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to update password of a non existent user", async () => {
+      const { _id } = await User.create({ email: "foo@mail", password: "foobar" });
+      await User.deleteOne({ _id });
+      await authUser
+        .post(`/api/password/update/${_id}`)
+        .send({ password: "foobar", new_password: "foo_bar", new_password_conf: "foo_bar" })
+        .expect('Content-Type', /json/)
+        .expect(404);
+    });
+
+    it("can update a user's password", async () => {
+      const { _id } = await User.create({ email: "foo@mail", password: "foobar" });
+      await authUser
+        .post(`/api/password/update/${_id}`)
+        .send({ password: "foobar", new_password: "foo_bar", new_password_conf: "foo_bar" })
+        .expect('Content-Type', /json/)
+        .expect(200);
+    });
+
+    it("tries to reset password without an email", async () => {
+      await authUser
+        .post("/api/password/reset/")
+        .send({})
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to reset password for a non existent user", async () => {
+      const { email } = await User.create({ email: "foo@mail", password: "foobar" });
+      await User.deleteOne({ email });
+      await authUser
+        .post("/api/password/reset/")
+        .send({ email })
+        .expect('Content-Type', /json/)
+        .expect(404);
+    });
+
+    it("successfully sends an email with link to update password", async () => {
+      const { email } = await User.create({ email: "foo@mail", password: "foobar" });
+      await authUser
+        .post("/api/password/reset/")
+        .send({ email })
+        .expect('Content-Type', /json/)
+        .expect(200);
+    });
+
+    it("tries to set a new password without a token", async () => {
+      await request(app)
+        .post("/api/password/new/")
+        .send({ new_password: "foobar", new_password_conf: "foobar" })
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to set a new password without it", async () => {
+      await User.create({
+        email: "foo@mail",
+        password: "foobar",
+        passwordToken: "_foo_",
+        passwordTokenExp: Date.now() + 360000
+      });
+      await request(app)
+        .post("/api/password/new/")
+        .send({ new_password_conf: "foobar", token: "_foo_" })
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to set a new password without its confirmation", async () => {
+      await User.create({
+        email: "foo@mail",
+        password: "foobar",
+        passwordToken: "_foo_",
+        passwordTokenExp: Date.now() + 360000
+      });
+      await request(app)
+        .post("/api/password/new/")
+        .send({ new_password: "foobar", token: "_foo_" })
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to set a new password with length < 5", async () => {
+      await User.create({
+        email: "foo@mail",
+        password: "foobar",
+        passwordToken: "_foo_",
+        passwordTokenExp: Date.now() + 360000
+      });
+      await request(app)
+        .post("/api/password/new/")
+        .send({ new_password: "bar", new_password_conf: "bar", token: "_foo_" })
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to set a new password with its confirmation being different", async () => {
+      await User.create({
+        email: "foo@mail",
+        password: "foobar",
+        passwordToken: "_foo_",
+        passwordTokenExp: Date.now() + 360000
+      });
+      await request(app)
+        .post("/api/password/new/")
+        .send({ new_password: "foobar", new_password_conf: "foo_bar", token: "_foo_" })
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to set a new password for a non existent user", async () => {
+      await User.create({
+        email: "foo@mail",
+        password: "foobar",
+        passwordToken: "_foo_",
+        passwordTokenExp: Date.now() + 360000
+      });
+      await User.deleteOne({ passwordToken: "_foo_" });
+      await request(app)
+        .post("/api/password/new/")
+        .send({ new_password: "foobar", new_password_conf: "foobar", token: "_foo_" })
+        .expect('Content-Type', /json/)
+        .expect(404);
+    });
+
+    it("tries to set a new password with an expired token", async () => {
+      await User.create({
+        email: "foo@mail",
+        password: "foobar",
+        passwordToken: "_foo_",
+        passwordTokenExp: Date.now() + 1
+      });
+      await request(app)
+        .post("/api/password/new/")
+        .send({ new_password: "foobar", new_password_conf: "foobar", token: "_foo_" })
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("can set a new password", async () => {
+      await User.create({
+        email: "foo@mail",
+        password: "foobar",
+        passwordToken: "_foo_",
+        passwordTokenExp: Date.now() + 360000
+      });
+      await request(app)
+        .post("/api/password/new/")
+        .send({ new_password: "foobar", new_password_conf: "foobar", token: "_foo_" })
+        .expect('Content-Type', /json/)
+        .expect(200);
+    });
+  });
+});

--- a/backend/src/controllers/__tests__/professor.controller.test.js
+++ b/backend/src/controllers/__tests__/professor.controller.test.js
@@ -1,0 +1,290 @@
+const request = require("supertest");
+const mongoose = require("mongoose");
+
+const Professor = require("../../models/professor");
+const ProfessorController = require("../professor.controller");
+
+const { createServer, createAgent, login } = require("../../helpers/test");
+const connect = require("../../mongo");
+
+const app = createServer();
+connect("prof_controller_test");
+
+describe("Professor controller test", () => {
+
+  const authUser = createAgent(app);
+
+  beforeAll(async (done) => {
+    await Professor.deleteMany({});
+    login(authUser, done);
+  });
+
+  afterEach(async () => {
+    await Professor.deleteMany({});
+  });
+
+  afterAll(async () => {
+    await mongoose.connection.close();
+  });
+
+  it("has a module", () => {
+    expect(ProfessorController).toBeDefined();
+  });
+
+  describe("professor controllers test", () => {
+    it("is unauthorized to list professors", async () => {
+      await request(app)
+        .get("/api/professors")
+        .expect('Content-Type', /json/)
+        .expect(401);
+    });
+
+    it("can list professors", async () => {
+      await authUser
+        .get("/api/professors")
+        .expect('Content-Type', /json/)
+        .expect(200);
+    });
+
+    it("is unauthorized to get professor", async () => {
+      const { _id } = await Professor.create({ email: "foo@mail" });
+      await request(app)
+        .get(`/api/professors/${_id}`)
+        .expect('Content-Type', /json/)
+        .expect(401);
+    });
+
+    it("tries to get a non existent professor", async () => {
+      const { _id } = await Professor.create({ email: "foo@mail" });
+      await Professor.deleteOne({ email: "foo@mail" });
+      await authUser
+        .get(`/api/professors/${_id}`)
+        .expect('Content-Type', /json/)
+        .expect(404);
+    });
+
+    it("can get professor", async () => {
+      const { _id } = await Professor.create({ email: "foo@mail" });
+      await authUser
+        .get(`/api/professors/${_id}`)
+        .expect('Content-Type', /json/)
+        .expect(200);
+    });
+
+    it("is unauthorized to invite a professor", async () => {
+      await request(app)
+        .post("/api/professors/invite")
+        .send({})
+        .expect('Content-Type', /json/)
+        .expect(401);
+    });
+
+    it("tries to invite a professor without an email", async () => {
+      await authUser
+        .post("/api/professors/invite")
+        .send({})
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to invite a professor that is active already", async () => {
+      const { email } = await Professor.create({ email: "foo@mail", status: "active" });
+      await authUser
+        .post("/api/professors/invite")
+        .send({ email })
+        .expect('Content-Type', /json/)
+        .expect(409);
+    });
+
+    it("tries to invite a professor that has a pending invite", async () => {
+      const { email } = await Professor.create({ email: "foo@mail", status: "invited" });
+      await authUser
+        .post("/api/professors/invite")
+        .send({ email })
+        .expect('Content-Type', /json/)
+        .expect(200);
+    });
+
+    it("tries to create a professor without an invite token", async () => {
+      const prof = { name: "foo", password: "foobar", password_conf: "foobar", phone: "9999" };
+      await authUser
+        .post("/api/professors/")
+        .send(prof)
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to create a professor without a name", async () => {
+      const prof = { name: "foo", password: "foobar", password_conf: "foobar", phone: "9999", inviteToken: "foobar" };
+      await authUser
+        .post("/api/professors/")
+        .send(prof)
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to create a professor without a password", async () => {
+      const prof = { name: "foo", password_conf: "foobar", phone: "9999", inviteToken: "foobar" };
+      await authUser
+        .post("/api/professors/")
+        .send(prof)
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to create a professor without a password confirmation", async () => {
+      const prof = { name: "foo", password: "foobar", phone: "9999", inviteToken: "foobar" };
+      await authUser
+        .post("/api/professors/")
+        .send(prof)
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to create a professor without a phone", async () => {
+      const prof = { name: "foo", password: "foobar", password_conf: "foobar", inviteToken: "foobar" };
+      await authUser
+        .post("/api/professors/")
+        .send(prof)
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to create a professor with an invalid invite token", async () => {
+      const prof = await Professor.create({ email: "foo@mail", status: "invited", inviteToken: "foobar", inviteTokenExp: Date.now() + 360000 });
+      const invitedProf = { name: "foo", password: "foobar", password_conf: "foobar", email: prof.email, phone: "9999", inviteToken: "foo_bar" };
+      await authUser
+        .post("/api/professors/")
+        .send(invitedProf)
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to create a professor with an expired invite token", async () => {
+      const prof = await Professor.create({ email: "foo@mail", status: "invited", inviteToken: "foobar", inviteTokenExp: Date.now() });
+      const invitedProf = { name: "foo", password: "foobar", password_conf: "foobar", email: prof.email, phone: "9999", inviteToken: "foobar" };
+      await authUser
+        .post("/api/professors/")
+        .send(invitedProf)
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to create a professor when his password and its confirmation are different", async () => {
+      const prof = await Professor.create({ email: "foo@mail", status: "invited", inviteToken: "foobar", inviteTokenExp: Date.now() + 360000 });
+      const invitedProf = { name: "foo", password: "foobar", password_conf: "foo_bar", email: prof.email, phone: "9999", inviteToken: "foobar" };
+      await authUser
+        .post("/api/professors/")
+        .send(invitedProf)
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("creates a professor", async () => {
+      const prof = await Professor.create({ email: "foo@mail", status: "invited", inviteToken: "foobar", inviteTokenExp: Date.now() + 360000 });
+      const invitedProf = { name: "foo", password: "foobar", password_conf: "foobar", email: prof.email, phone: "9999", inviteToken: "foobar" };
+      await authUser
+        .post("/api/professors/")
+        .send(invitedProf)
+        .expect('Content-Type', /json/)
+        .expect(201);
+    });
+
+    it("is unauthorized to delete a professor", async () => {
+      const { _id } = await Professor.create({ email: "foo@mail" });
+      await request(app)
+        .delete(`/api/professors/${_id}`)
+        .expect('Content-Type', /json/)
+        .expect(401);
+    });
+
+    it("tries to delete a non existent professor", async () => {
+      const { _id } = await Professor.create({ email: "foo@mail" });
+      await Professor.deleteOne({ email: "foo@mail" });
+      await authUser
+        .delete(`/api/professors/${_id}`)
+        .expect('Content-Type', /json/)
+        .expect(404);
+    });
+
+    it("can delete a professor", async () => {
+      const { _id } = await Professor.create({ email: "foo@mail" });
+      await authUser
+        .delete(`/api/professors/${_id}`)
+        .expect('Content-Type', /json/)
+        .expect(202);
+    });
+
+    it("is unauthorized to update a professor", async () => {
+      const { _id } = await Professor.create({ email: "foo@mail" });
+      await request(app)
+        .put(`/api/professors/${_id}`)
+        .send({ name: "foo" })
+        .expect('Content-Type', /json/)
+        .expect(401);
+    });
+
+    it("tries to update a professor without an email", async () => {
+      const { _id } = await Professor.create({ name: "foo", email: "foo@mail", phone: "9999" });
+      await authUser
+        .put(`/api/professors/${_id}`)
+        .send({ name: "foo", phone: "9999" })
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to update a professor without a name", async () => {
+      const { _id } = await Professor.create({ name: "foo", email: "foo@mail", phone: "9999" });
+      await authUser
+        .put(`/api/professors/${_id}`)
+        .send({ email: "foo@mail", phone: "9999" })
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to update a professor without a phone", async () => {
+      const { _id } = await Professor.create({ name: "foo", email: "foo@mail", phone: "9999" });
+      await authUser
+        .put(`/api/professors/${_id}`)
+        .send({ name: "foo", email: "foo@mail" })
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to update a professor that is not me", async () => {
+      const { _id } = await Professor.create({ name: "foo", email: "foo@mail", phone: "9999", password: "foobar" });
+      await authUser
+        .put(`/api/professors/${_id}`)
+        .send({ name: "bar", email: "foo@mail", phone: "9999" })
+        .expect('Content-Type', /json/)
+        .expect(403);
+    });
+
+    it("tries to update a non existent professor", async () => {
+      const { _id, email } = await Professor.create({ name: "foo", email: "foo@mail", phone: "9999", password: "foobar" });
+      const AuthMe = request.agent(app);
+      await AuthMe
+        .post("/api/auth/login")
+        .send({ email, password: "foobar" });
+      await Professor.deleteOne({ email });
+      await AuthMe
+        .put(`/api/professors/${_id}`)
+        .send({ name: "bar", email: "foo@mail", phone: "9999" })
+        .expect('Content-Type', /json/)
+        .expect(404);
+    });
+
+    it("can update a professor", async () => {
+      const { _id, email } = await Professor.create({ name: "foo", email: "foo@mail", phone: "9999", password: "foobar" });
+      const AuthMe = request.agent(app);
+      await AuthMe
+        .post("/api/auth/login")
+        .send({ email, password: "foobar" });
+      await AuthMe
+        .put(`/api/professors/${_id}`)
+        .send({ name: "bar", email: "foo@mail", phone: "9999" })
+        .expect('Content-Type', /json/)
+        .expect(200);
+    });
+  });
+});

--- a/backend/src/controllers/__tests__/user.controller.test.js
+++ b/backend/src/controllers/__tests__/user.controller.test.js
@@ -1,0 +1,181 @@
+const request = require("supertest");
+const mongoose = require("mongoose");
+
+const User = require("../../models/user");
+const UserController = require("../user.controller");
+
+const { createServer, createAgent, login } = require("../../helpers/test");
+const connect = require("../../mongo");
+
+const app = createServer();
+connect("user_controller_test");
+
+describe("User controller test", () => {
+
+  const authUser = createAgent(app);
+
+  beforeAll(async (done) => {
+    await User.deleteMany({});
+    login(authUser, done);
+  });
+
+  afterEach(async () => {
+    await User.deleteMany({});
+  });
+
+  afterAll(async () => {
+    await mongoose.connection.close();
+  });
+
+  it("has a module", () => {
+    expect(UserController).toBeDefined();
+  });
+
+  describe("user controllers test", () => {
+    it("is unauthorized to list users", async () => {
+      await request(app)
+        .get("/api/users")
+        .expect('Content-Type', /json/)
+        .expect(401);
+    });
+
+    it("can list users", async () => {
+      await authUser
+        .get("/api/users")
+        .expect('Content-Type', /json/)
+        .expect(200);
+    });
+
+    it("is unauthorized to get user", async () => {
+      const { _id } = await User.create({ email: "foo@mail" });
+      await request(app)
+        .get(`/api/users/${_id}`)
+        .expect('Content-Type', /json/)
+        .expect(401);
+    });
+
+    it("tries to get a non existent user", async () => {
+      const { _id } = await User.create({ email: "foo@mail" });
+      await User.deleteOne({ email: "foo@mail" });
+      await authUser
+        .get(`/api/users/${_id}`)
+        .expect('Content-Type', /json/)
+        .expect(404);
+    });
+
+    it("can get user", async () => {
+      const { _id } = await User.create({ email: "foo@mail" });
+      await authUser
+        .get(`/api/users/${_id}`)
+        .expect('Content-Type', /json/)
+        .expect(200);
+    });
+
+    it("is unauthorized to create a user", async () => {
+      const user = { name: "foo", email: "foo@mail", password: "bar" };
+      await request(app)
+        .post("/api/users/")
+        .send(user)
+        .expect('Content-Type', /json/)
+        .expect(401);
+    });
+
+    it("can create a user", async () => {
+      const user = { name: "foo", email: "foo@mail", password: "foobar" };
+      await authUser
+        .post("/api/users/")
+        .send(user)
+        .expect('Content-Type', /json/)
+        .expect(201);
+    });
+
+    it("tries to create a user without a name", async () => {
+      const user = { email: "foo@mail", password: "foobar" };
+      await authUser
+        .post("/api/users/")
+        .send(user)
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to create a user without a password", async () => {
+      const user = { name: "foo", email: "foo@mail" };
+      await authUser
+        .post("/api/users/")
+        .send(user)
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to create a user with password's length < 5", async () => {
+      const user = { name: "foo", email: "foo@mail", password: "bar" };
+      await authUser
+        .post("/api/users/")
+        .send(user)
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it("tries to create a duplicated user", async () => {
+      await User.create({ name: "foo", email: "foo@mail", password: "foobar" });
+      await authUser
+        .post("/api/users/")
+        .send({ name: "bar", email: "foo@mail", password: "foobar" })
+        .expect('Content-Type', /json/)
+        .expect(409);
+    });
+
+    it("is unauthorized to delete a user", async () => {
+      const { _id } = await User.create({ email: "foo@mail" });
+      await request(app)
+        .delete(`/api/users/${_id}`)
+        .expect('Content-Type', /json/)
+        .expect(401);
+    });
+
+    it("tries to delete a non existent user", async () => {
+      const { _id } = await User.create({ email: "foo@mail" });
+      await User.deleteOne({ email: "foo@mail" });
+      await authUser
+        .delete(`/api/users/${_id}`)
+        .expect('Content-Type', /json/)
+        .expect(404);
+    });
+
+    it("can delete a user", async () => {
+      const { _id } = await User.create({ email: "foo@mail" });
+      await authUser
+        .delete(`/api/users/${_id}`)
+        .expect('Content-Type', /json/)
+        .expect(202);
+    });
+
+    it("is unauthorized to update a user", async () => {
+      const { _id } = await User.create({ email: "foo@mail" });
+      await request(app)
+        .put(`/api/users/${_id}`)
+        .send({ name: "foo" })
+        .expect('Content-Type', /json/)
+        .expect(401);
+    });
+
+    it("tries to update a non existent user", async () => {
+      const { _id } = await User.create({ email: "foo@mail" });
+      await User.deleteOne({ email: "foo@mail" });
+      await authUser
+        .put(`/api/users/${_id}`)
+        .send({ name: "foo" })
+        .expect('Content-Type', /json/)
+        .expect(404);
+    });
+
+    it("can update a user", async () => {
+      const { _id } = await User.create({ email: "foo@mail" });
+      await authUser
+        .put(`/api/users/${_id}`)
+        .send({ name: "foo" })
+        .expect('Content-Type', /json/)
+        .expect(200);
+    });
+  });
+});

--- a/backend/src/controllers/auth.controller.js
+++ b/backend/src/controllers/auth.controller.js
@@ -10,7 +10,7 @@ const { AuthMiddleware, VerifyRefreshToken } = require("../middlewares/auth.midd
 const AuthService = require("../services/auth.service");
 const UserService = require("../services/user.service");
 
-const { handleError, ErrorHandler } = require("../helpers/error");
+const { handleError, ErrorHandler, BadRequestError } = require("../helpers/error");
 const { clearCookies } = require("../helpers/cookie");
 const jwtConfig = require("../jwt");
 
@@ -18,16 +18,15 @@ router.post(
   "/login",
   [
     check("email").not().isEmpty().withMessage("Email is missing"),
-    check("password")
-      .isLength({ min: 5 })
-      .withMessage("Password must have at least 5 chars long"),
+    check("password").not().isEmpty().withMessage("Password is missing"),
   ],
   async (req, res) => {
-    const errors = validationResult(req);
-    if (!errors.isEmpty()) {
-      return res.status(400).json(errors.array());
-    }
     try {
+      const errors = validationResult(req);
+      if (!errors.isEmpty()) {
+        throw new BadRequestError(errors.array());
+      }
+
       const { email, password } = req.body;
       const user = await AuthService.getUserWithPassword({ email });
       if (!user) {

--- a/backend/src/controllers/lesson.controller.js
+++ b/backend/src/controllers/lesson.controller.js
@@ -3,59 +3,63 @@ const express = require("express");
 const { AuthMiddleware } = require("../middlewares/auth.middleware");
 const LessonService = require("../services/lesson.service");
 
-const { NotFoundError } = require("../helpers/error");
+const { NotFoundError, handleError } = require("../helpers/error");
 
 const router = express.Router();
 
 const ENTITY_NAME = "Lesson";
 
 router.get("/:id", AuthMiddleware, async (req, res, next) => {
-  const { id } = req.params;
+  try {
+    const { id } = req.params;
+    const lesson = await LessonService.getLessonById(id);
 
-  const lesson = await LessonService.getLessonById(id);
+    if (!lesson) {
+      throw new NotFoundError(ENTITY_NAME);
+    };
 
-  if (!lesson) {
-    return next(new NotFoundError(ENTITY_NAME));
-  };
-
-  return res.status(200).json({
-    status: 200,
-    lesson,
-  });
+    return res.status(200).json({
+      status: 200,
+      lesson,
+    });
+  } catch (e) {
+    handleError(e, res);
+  }
 });
 
 router.put("/:id", AuthMiddleware, async (req, res, next) => {
-
   try {
     const { id } = req.params;
     const lesson = await LessonService.updateLesson(id, req.body);
 
     if (!lesson) {
-      return next(new NotFoundError(ENTITY_NAME));
+      throw new NotFoundError(ENTITY_NAME);
     }
 
+    return res.status(200).json({
+      status: 200,
+    });
   } catch (e) {
-    return next(e);
-  };
-
-  return res.status(200).json({
-    status: 200,
-  });
-})
+    handleError(e, res);
+  }
+});
 
 
 router.delete("/:id", AuthMiddleware, async (req, res, next) => {
-  const { id } = req.params;
+  try {
+    const { id } = req.params;
+    const lesson = await LessonService.deleteLesson(id);
 
-  const lesson = await LessonService.deleteLesson(id);
+    if (!lesson) {
+      throw new NotFoundError(ENTITY_NAME);
+    }
 
-  if (!lesson) {
-    return next(new NotFoundError(ENTITY_NAME));
+    return res.status(202).json({
+      status: 202,
+    });
+  } catch (e) {
+    handleError(e, res);
   }
-
-  return res.status(202).json({
-    status: 202,
-  });
-})
+});
 
 module.exports = router;

--- a/backend/src/controllers/mail.controller.js
+++ b/backend/src/controllers/mail.controller.js
@@ -4,7 +4,7 @@ const router = express.Router();
 const { check, validationResult } = require("express-validator");
 
 const MailService = require("../services/mail.service");
-const { handleError } = require("../helpers/error");
+const { handleError, BadRequestError } = require("../helpers/error");
 
 router.post(
   "/",
@@ -14,12 +14,12 @@ router.post(
     check("message").not().isEmpty().withMessage("Message is missing"),
   ],
   async (req, res) => {
-    const errors = validationResult(req);
-    if (!errors.isEmpty()) {
-      return res.status(400).json(errors.array());
-    }
-
     try {
+      const errors = validationResult(req);
+      if (!errors.isEmpty()) {
+        throw new BadRequestError(errors.array());
+      }
+
       const { name, email, message } = req.body;
       const { EMAIL_FROM } = process.env;
 

--- a/backend/src/controllers/professor.controller.js
+++ b/backend/src/controllers/professor.controller.js
@@ -57,7 +57,7 @@ router.post(
     try {
       const { inviteToken } = req.body;
 
-      let professor = await ProfessorService.getProfessor({ inviteToken });
+      let professor = await ProfessorService.getProfessorWithToken({ inviteToken });
       if (!professor) {
         throw new ErrorHandler(400, "Invalid token");
       }

--- a/backend/src/helpers/cookie.js
+++ b/backend/src/helpers/cookie.js
@@ -1,4 +1,4 @@
-exports.parseCookie = async cookie => {
+const parseCookie = async cookie => {
   const rawCookies = cookie.split(";");
   const parsedCookies = {};
 
@@ -10,8 +10,13 @@ exports.parseCookie = async cookie => {
   return parsedCookies;
 };
 
-exports.clearCookies = res => {
+const clearCookies = res => {
   res.clearCookie("token");
   res.clearCookie("refresh_token");
   return res;
 };
+
+module.exports = {
+  parseCookie,
+  clearCookies,
+}

--- a/backend/src/helpers/test.js
+++ b/backend/src/helpers/test.js
@@ -1,0 +1,37 @@
+const express = require("express");
+const request = require("supertest");
+
+const User = require("../models/user");
+
+const createServer = () => {
+  const app = express();
+  app.use(express.json());
+  app.use("/api", require("../controllers/index"));
+  return app;
+};
+
+const createAgent = app => {
+  return request.agent(app);
+};
+
+const login = async (user, done) => {
+  const admin = { email: "admin@mail", password: "admin" };
+  await User.create(admin);
+
+  user
+    .post("/api/auth/login")
+    .send(admin)
+    .end((err, resp) => {
+      if (err) {
+        throw err;
+      }
+      done();
+    });
+};
+
+
+module.exports = {
+  createServer,
+  createAgent,
+  login,
+};

--- a/backend/src/helpers/test.js
+++ b/backend/src/helpers/test.js
@@ -15,6 +15,7 @@ const createAgent = app => {
 };
 
 const login = async (user, done) => {
+  await User.deleteMany({});
   const admin = { email: "admin@mail", password: "admin" };
   await User.create(admin);
 

--- a/backend/src/middlewares/auth.middleware.js
+++ b/backend/src/middlewares/auth.middleware.js
@@ -4,7 +4,7 @@ const { parseCookie } = require("../helpers/cookie");
 
 const { TOKEN_SECRET, REFRESH_TOKEN_SECRET } = process.env;
 
-exports.AuthMiddleware = async (req, res, next) => {
+const AuthMiddleware = async (req, res, next) => {
   const { headers } = req;
 
   const cookie = headers ? headers.cookie : null;
@@ -36,15 +36,14 @@ exports.AuthMiddleware = async (req, res, next) => {
   });
 };
 
-exports.VerifyRefreshToken = async (req, res, next) => {
+const VerifyRefreshToken = async (req, res, next) => {
   const { headers } = req;
-
   const cookie = headers ? headers.cookie : null;
 
   if (!cookie) {
     return res
       .status(401)
-      .send({ status: 401, message: "Refresh token is missing" });
+      .json({ status: 401, message: "Refresh token is missing" });
   }
 
   const parsedCookies = await parseCookie(cookie);
@@ -52,12 +51,12 @@ exports.VerifyRefreshToken = async (req, res, next) => {
   if (!refreshToken) {
     return res
       .status(401)
-      .send({ status: 401, message: "Refresh token is invalid or missing" });
+      .json({ status: 401, message: "Refresh token is invalid or missing" });
   }
 
   jwt.verify(refreshToken, REFRESH_TOKEN_SECRET, (err, decoded) => {
     if (err) {
-      return res.status(401).send({ status: 401, message: err.message });
+      return res.status(401).json({ status: 401, message: err.message });
     }
     req.authContext = {
       refreshToken,
@@ -65,4 +64,9 @@ exports.VerifyRefreshToken = async (req, res, next) => {
 
     next();
   });
+};
+
+module.exports = {
+  AuthMiddleware,
+  VerifyRefreshToken,
 };

--- a/backend/src/services/professor.service.js
+++ b/backend/src/services/professor.service.js
@@ -29,6 +29,14 @@ const getProfessor = async (params) => {
   }
 };
 
+const getProfessorWithToken = async (params) => {
+  try {
+    return await Professor.findOne(params).select(['inviteToken', 'inviteTokenExp']);
+  } catch (e) {
+    throw new ErrorHandler(500, e.errmsg);
+  }
+};
+
 const deleteProfessor = async (id) => {
   try {
     return await Professor.findByIdAndDelete(id);
@@ -49,6 +57,7 @@ module.exports = {
   getProfessors,
   createProfessor,
   getProfessor,
+  getProfessorWithToken,
   deleteProfessor,
   updateProfessor,
 };


### PR DESCRIPTION
## Tipo da mudança

- [x] Adição de testes

# Descrição
- Adiciona o `supertest` como dependência
- Adiciona testes para os controllers: `user`, `professor`, `course`, `lesson`, `password`, `mail` e `auth`
- Algumas refatorações relacionadas a retorno de erros e forma como as funções são exportadas

Resolve #76 

# Como foi testado?

Para rodar os testes, basta entrar com o comando: `docker-compose -f docker-compose.test.yml up backend`

> É importante especificar as variáveis de ambiente relacionadas à conta de email no arquivo `.env/test/app.env` para que os testes que enviam emails possam ser executados.

# Checklist:

- [x] Fiz uma revisão própria do código
- [x] Testes novos e existentes ainda passam com esta mudança
