### PR TITLE
Integração detalhe de um PS #107

### DIFF
--- a/backend/src/calendar/helpers/__tests__/addStatus.test.js
+++ b/backend/src/calendar/helpers/__tests__/addStatus.test.js
@@ -1,0 +1,83 @@
+const { addStatus } = require("../addStatus");
+const { processStatus } = require("../processStatus");
+
+describe("addStatus test", () => {
+  it("has a module", () => {
+    expect(addStatus).toBeDefined();
+  });
+
+  it("has an empty list of events", async () => {
+    let events = [];
+    expect(await addStatus(events)).toEqual([]);
+  });
+
+  it("has events with no attendees", async () => {
+    let events = [
+      {
+        summary: "Event 1"
+      },
+      {
+        summary: "Event 2"
+      },
+    ];
+    let result = [
+      {
+        summary: "Event 1",
+        processStatus: processStatus.EMPTY,
+      },
+      {
+        summary: "Event 2",
+        processStatus: processStatus.EMPTY,
+      },
+    ]
+    expect(await addStatus(events)).toEqual(result);
+  });
+
+  it("has events with attendees but no confirmation", async () => {
+    let events = [
+      {
+        summary: "Event 1",
+        attendees: [{ email: "foo@bar", responseStatus: "needsAction" }],
+      },
+      {
+        summary: "Event 2",
+      },
+    ];
+    let result = [
+      {
+        summary: "Event 1",
+        attendees: [{ email: "foo@bar", responseStatus: "needsAction" }],
+        processStatus: processStatus.PENDING,
+      },
+      {
+        summary: "Event 2",
+        processStatus: processStatus.EMPTY,
+      },
+    ]
+    expect(await addStatus(events)).toEqual(result);
+  });
+
+  it("has events with attendees and their confirmation", async () => {
+    let events = [
+      {
+        summary: "Event 1",
+        attendees: [{ email: "foo@bar", responseStatus: "confirmed" }],
+      },
+      {
+        summary: "Event 2",
+      },
+    ];
+    let result = [
+      {
+        summary: "Event 1",
+        attendees: [{ email: "foo@bar", responseStatus: "confirmed" }],
+        processStatus: processStatus.CONFIRMED,
+      },
+      {
+        summary: "Event 2",
+        processStatus: processStatus.EMPTY,
+      },
+    ]
+    expect(await addStatus(events)).toEqual(result);
+  });
+});

--- a/backend/src/calendar/helpers/__tests__/separateByDays.test.js
+++ b/backend/src/calendar/helpers/__tests__/separateByDays.test.js
@@ -1,0 +1,55 @@
+const { separateByDays } = require("../separateByDays");
+
+describe("separateByDays test", () => {
+  it("has a module", () => {
+    expect(separateByDays).toBeDefined();
+  });
+
+  it("receives an empty list", async () => {
+    expect(await separateByDays([])).toEqual({});
+  });
+
+  it("has start.dateTime", async () => {
+    const today = new Date();
+
+    const events = [
+      {
+        start: {
+          dateTime: today,
+        },
+      },
+      {
+        start: {
+          dateTime: today,
+        },
+      }
+    ];
+    const date = today.getDate() + "/" + (today.getMonth() + 1) + "/" + today.getFullYear();
+    const result = {};
+    result[date] = [...events];
+    expect(await separateByDays(events)).toMatchObject(result);
+  });
+
+  it("has start.date", async () => {
+    const today = new Date();
+    const date = today.getDate() + "/" + (today.getMonth() + 1) + "/" + today.getFullYear();
+
+    const events = [
+      {
+        summary: "Event 1",
+        start: {
+          date,
+        },
+      },
+      {
+        summary: "Event 2",
+        start: {
+          date,
+        },
+      }
+    ];
+    let result = {};
+    result[date] = [...events];
+    expect(await separateByDays(events)).toMatchObject(result);
+  });
+});

--- a/backend/src/calendar/helpers/addStatus.js
+++ b/backend/src/calendar/helpers/addStatus.js
@@ -12,6 +12,7 @@ const addStatus = async (events) => {
       e["processStatus"] = processStatus.EMPTY;
     }
   });
+  return events;
 }
 
 module.exports = {

--- a/backend/src/calendar/helpers/addStatus.js
+++ b/backend/src/calendar/helpers/addStatus.js
@@ -1,0 +1,19 @@
+const { processStatus } = require("./processStatus");
+
+const addStatus = async (events) => {
+  await events.forEach(e => {
+    if (e.attendees) {
+      if (e.attendees.find(attendee => attendee.responseStatus === "needsAction")) {
+        e["processStatus"] = processStatus.PENDING;
+      } else {
+        e["processStatus"] = processStatus.CONFIRMED;
+      }
+    } else {
+      e["processStatus"] = processStatus.EMPTY;
+    }
+  });
+}
+
+module.exports = {
+  addStatus,
+};

--- a/backend/src/calendar/helpers/processStatus.js
+++ b/backend/src/calendar/helpers/processStatus.js
@@ -1,0 +1,18 @@
+const processStatus = {
+  EMPTY: {
+    status: "Vago",
+    color: "orange",
+  },
+  PENDING: {
+    status: "Pendente",
+    color: "blue",
+  },
+  CONFIRMED: {
+    status: "Confirmado",
+    color: "green",
+  },
+};
+
+module.exports = {
+  processStatus,
+};

--- a/backend/src/calendar/helpers/separateByDays.js
+++ b/backend/src/calendar/helpers/separateByDays.js
@@ -5,10 +5,10 @@ const separateByDays = async (events) => {
     let date;
     if (e.start.dateTime) {
       date = new Date(e.start.dateTime);
+      date = date.getDate() + "/" + (date.getMonth() + 1) + "/" + date.getFullYear();
     } else if (e.start.date) {
-      date = new Date(e.start.date);
+      date = e.start.date;
     }
-    date = date.getDate() + "/" + (date.getMonth() + 1) + "/" + date.getFullYear();
     if (items[date] !== undefined) {
       items[date].push(e);
     } else {

--- a/backend/src/calendar/helpers/separateByDays.js
+++ b/backend/src/calendar/helpers/separateByDays.js
@@ -1,0 +1,23 @@
+const separateByDays = async (events) => {
+  let items = {};
+
+  await events.forEach(e => {
+    let date;
+    if (e.start.dateTime) {
+      date = new Date(e.start.dateTime);
+    } else if (e.start.date) {
+      date = new Date(e.start.date);
+    }
+    date = date.getDate() + "/" + (date.getMonth() + 1) + "/" + date.getFullYear();
+    if (items[date] !== undefined) {
+      items[date].push(e);
+    } else {
+      items[date] = [e];
+    }
+  });
+  return items;
+}
+
+module.exports = {
+  separateByDays,
+};

--- a/backend/src/calendar/services/__tests__/listEvents.test.js
+++ b/backend/src/calendar/services/__tests__/listEvents.test.js
@@ -1,0 +1,7 @@
+const { listEvents } = require("../listEvents");
+
+describe("listEvents test", () => {
+  it("has a module", () => {
+    expect(listEvents).toBeDefined();
+  });
+});

--- a/backend/src/calendar/services/listEvents.js
+++ b/backend/src/calendar/services/listEvents.js
@@ -1,0 +1,15 @@
+const { calendar } = require("../calendar");
+
+const listEvents = async (id, start) => {
+  const res = await calendar.events.list({
+    calendarId: id,
+    timeMin: start,
+    singleEvents: true,
+    orderBy: "startTime",
+  });
+  return res.data.items;
+}
+
+module.exports = {
+  listEvents,
+};

--- a/backend/src/calendar/services/listEvents.js
+++ b/backend/src/calendar/services/listEvents.js
@@ -1,9 +1,10 @@
 const { calendar } = require("../calendar");
 
-const listEvents = async (id, start) => {
+const listEvents = async (id, start, end) => {
   const res = await calendar.events.list({
     calendarId: id,
     timeMin: start,
+    timeMax: end,
     singleEvents: true,
     orderBy: "startTime",
   });

--- a/backend/src/controllers/recruitment.controller.js
+++ b/backend/src/controllers/recruitment.controller.js
@@ -75,7 +75,10 @@ router.get('/:name',
       }
 
       // Google Calendar events
-      const events = await listEvents(process.calendarId, process.beginningDate);
+      let events;
+      if (process.calendarId) {
+        events = await listEvents(process.calendarId, process.beginningDate);
+      }
 
       return res.status(200).json({
         status: 200,

--- a/backend/src/controllers/recruitment.controller.js
+++ b/backend/src/controllers/recruitment.controller.js
@@ -8,6 +8,8 @@ const InterviewService = require("../services/interview.service");
 const { createCalendar } = require("../calendar/services/createCalendar");
 const { editCalendar } = require("../calendar/services/editCalendar");
 const { listEvents } = require("../calendar/services/listEvents");
+const { addStatus } = require("../calendar/helpers/addStatus");
+const { separateByDays } = require("../calendar/helpers/separateByDays");
 
 const { BadRequestError, handleError, NotFoundError } = require('../helpers/error');
 
@@ -75,9 +77,16 @@ router.get('/:name',
       }
 
       // Google Calendar events
-      let events;
+      let events = [];
       if (process.calendarId) {
-        events = await listEvents(process.calendarId, process.beginningDate);
+        events = await listEvents(process.calendarId, process.beginningDate, process.endDate);
+      }
+
+      if (events && events.length > 0) {
+        // add a status for each event
+        await addStatus(events);
+        // divide by days
+        events = await separateByDays(events);
       }
 
       return res.status(200).json({

--- a/backend/src/controllers/recruitment.controller.js
+++ b/backend/src/controllers/recruitment.controller.js
@@ -7,6 +7,7 @@ const InterviewService = require("../services/interview.service");
 
 const { createCalendar } = require("../calendar/services/createCalendar");
 const { editCalendar } = require("../calendar/services/editCalendar");
+const { listEvents } = require("../calendar/services/listEvents");
 
 const { BadRequestError, handleError, NotFoundError } = require('../helpers/error');
 
@@ -73,9 +74,13 @@ router.get('/:name',
         throw new NotFoundError(ENTITY_NAME);
       }
 
+      // Google Calendar events
+      const events = await listEvents(process.calendarId, process.beginningDate);
+
       return res.status(200).json({
         status: 200,
         process,
+        events,
       });
     }
     catch (e) {

--- a/frontend/src/routes/router.js
+++ b/frontend/src/routes/router.js
@@ -43,8 +43,8 @@ const router = (
 
     <PrivateRoute path={routes.RECRUITMENT_INSTRUCTIONS} component={Instructions} />
     <PrivateRoute path={routes.PROCESS_EDIT} component={ProcessEdit} />
-    <PrivateRoute path={routes.PROCESS_DETAIL} component={ProcessDetail} />
     <PrivateRoute path={routes.PROCESS_NEW} component={ProcessNew} />
+    <PrivateRoute path={routes.PROCESS_DETAIL} component={ProcessDetail} />
     <PrivateRoute path={routes.RECRUITMENT} component={Recruitment} />
 
     <PrivateRoute path={routes.MY_AREA_ID} component={Profile} />

--- a/frontend/src/routes/router.js
+++ b/frontend/src/routes/router.js
@@ -33,6 +33,7 @@ import LessonEdit from "views/Lesson/LessonEdit/LessonEdit";
 import Recruitment from "views/Recruitment/Recruitment";
 import ProcessNew from "views/Recruitment/ProcessNew/ProcessNew";
 import ProcessEdit from "views/Recruitment/ProcessEdit/ProcessEdit";
+import ProcessDetail from "views/Recruitment/ProcessDetail/ProcessDetail";
 import Instructions from "views/Recruitment/Instructions/Instructions";
 
 const router = (
@@ -42,6 +43,7 @@ const router = (
 
     <PrivateRoute path={routes.RECRUITMENT_INSTRUCTIONS} component={Instructions} />
     <PrivateRoute path={routes.PROCESS_EDIT} component={ProcessEdit} />
+    <PrivateRoute path={routes.PROCESS_DETAIL} component={ProcessDetail} />
     <PrivateRoute path={routes.PROCESS_NEW} component={ProcessNew} />
     <PrivateRoute path={routes.RECRUITMENT} component={Recruitment} />
 

--- a/frontend/src/routes/routes.js
+++ b/frontend/src/routes/routes.js
@@ -28,6 +28,7 @@ const routes = {
   RECRUITMENT: "/recruitment",
   PROCESS_NEW: "/recruitment/new",
   PROCESS_EDIT: "/recruitment/:name/edit",
+  PROCESS_DETAIL: "/recruitment/:name",
   RECRUITMENT_INSTRUCTIONS: "/recruitment/instructions",
 };
 

--- a/frontend/src/views/Recruitment/ProcessDetail/ProcessDetail.js
+++ b/frontend/src/views/Recruitment/ProcessDetail/ProcessDetail.js
@@ -1,0 +1,87 @@
+import React, { useState, useEffect } from "react";
+
+import { get } from "services/recruitment.service";
+
+import { formatDateToReceive } from "helpers/masks";
+
+import Page from "components/Page/Page";
+import PageTitle from "components/PageTitle/PageTitle";
+import Container from "components/Container/Container";
+import Loader from "components/Loader/Loader";
+
+import { message, Tag, Statistic, Button } from "antd";
+import { ArrowLeftOutlined } from "@ant-design/icons";
+
+import styles from "./ProcessDetail.module.scss";
+
+const ProcessDetail = ({ history, match }) => {
+  const [name, setName] = useState("");
+  const [status, setStatus] = useState("");
+  const [beginningDate, setBeginningDate] = useState(null);
+  const [endDate, setEndDate] = useState(null);
+
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    const getProcess = (name) => {
+      setIsLoading(true);
+      get(name)
+        .then((response) => {
+          const { process } = response.data;
+          setName(process.name);
+          setStatus(process.status);
+          setBeginningDate(formatDateToReceive(process.beginningDate));
+          setEndDate(formatDateToReceive(process.endDate));
+        })
+        .catch(() => {
+          message.error("Ops! Aconteceu algum erro pra pegar os dados do Processo");
+        })
+        .finally(() => {
+          setIsLoading(false);
+        });
+    }
+    getProcess(match.params.name);
+  }, []);
+
+  const mapStatus = (status) => {
+    switch (status) {
+      case "active":
+        return <Tag color="green">Ativo</Tag>
+      case "done":
+        return <Tag color="blue">Finalizado</Tag>
+    }
+  };
+
+  return (
+    <Page>
+      <PageTitle title="Detalhes do PS" />
+      <Container>
+        {isLoading ? (
+          <div className="loader">
+            <Loader />
+          </div>
+        ) : (
+            <div className={styles.container}>
+              <div className={styles.button}>
+                <Button icon={<ArrowLeftOutlined />} onClick={() => history.goBack()}>Voltar</Button>
+              </div>
+              <div className={styles.title}>
+                <h1>{name}</h1>
+                {mapStatus(status)}
+              </div>
+              <div className={styles.dates}>
+                <div className={styles.date}>
+                  <Statistic title="Início" value={beginningDate} />
+                </div>
+                <div className={styles.date}>
+                  <Statistic title="Fim" value={endDate} />
+                </div>
+              </div>
+            </div>
+          )}
+      </Container>
+    </Page>
+  )
+}
+
+export default ProcessDetail;

--- a/frontend/src/views/Recruitment/ProcessDetail/ProcessDetail.js
+++ b/frontend/src/views/Recruitment/ProcessDetail/ProcessDetail.js
@@ -9,8 +9,8 @@ import PageTitle from "components/PageTitle/PageTitle";
 import Container from "components/Container/Container";
 import Loader from "components/Loader/Loader";
 
-import { message, Tag, Statistic, Button, Select, Table, Space } from "antd";
-import { ArrowLeftOutlined } from "@ant-design/icons";
+import { message, Tag, Statistic, Button, Select, Table, Tooltip } from "antd";
+import { ArrowLeftOutlined, QuestionCircleOutlined } from "@ant-design/icons";
 
 import styles from "./ProcessDetail.module.scss";
 
@@ -129,6 +129,14 @@ const ProcessDetail = ({ history, match }) => {
                     return <Option value={key}>{key}</Option>
                   })}
                 </Select>
+                <div className={styles.select__info}>
+                  <Tooltip
+                    title="Listados apenas os dias que contém pelo menos 1 evento"
+                    placement="bottom"
+                  >
+                    <QuestionCircleOutlined />
+                  </Tooltip>
+                </div>
               </div>
               <div className={styles.table}>
                 <Table

--- a/frontend/src/views/Recruitment/ProcessDetail/ProcessDetail.js
+++ b/frontend/src/views/Recruitment/ProcessDetail/ProcessDetail.js
@@ -13,6 +13,7 @@ import { message, Tag, Statistic, Button, Select, Table, Tooltip } from "antd";
 import { ArrowLeftOutlined, QuestionCircleOutlined } from "@ant-design/icons";
 
 import styles from "./ProcessDetail.module.scss";
+import columns from "./columns";
 
 const { Option } = Select;
 
@@ -65,38 +66,6 @@ const ProcessDetail = ({ history, match }) => {
     }
   };
 
-  const columns = [
-    {
-      title: "Evento",
-      dataIndex: "summary",
-      key: "name",
-    },
-    {
-      title: "Início",
-      dataIndex: ["start", "dateTime"],
-      key: "start",
-      render: value => value ? new Date(value).toTimeString().slice(0, 5) : "-"
-    },
-    {
-      title: "Fim",
-      dataIndex: ["end", "dateTime"],
-      key: "end",
-      render: value => value ? new Date(value).toTimeString().slice(0, 5) : "-"
-    },
-    {
-      title: "Status",
-      dataIndex: "processStatus",
-      key: "status",
-      render: value => <Tag color={value.color}>{value.status}</Tag>
-    },
-    {
-      title: "Meet",
-      dataIndex: "hangoutLink",
-      key: "hangoutLink",
-      render: value => value ? <a href={value} target="_blank">Link</a> : "-"
-    },
-  ];
-
   return (
     <Page>
       <PageTitle title="Detalhes do PS" />
@@ -144,6 +113,7 @@ const ProcessDetail = ({ history, match }) => {
                   dataSource={events[selectedDate]}
                   pagination={false}
                   scroll={{ x: 800 }}
+                  bordered
                 />
               </div>
             </div>

--- a/frontend/src/views/Recruitment/ProcessDetail/ProcessDetail.module.scss
+++ b/frontend/src/views/Recruitment/ProcessDetail/ProcessDetail.module.scss
@@ -18,6 +18,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
+    margin-bottom: var(--spacing-huge);
 
     .date {
       margin: var(--spacing-base) 0;
@@ -35,5 +36,14 @@
       flex-direction: row;
       justify-content: center;
     }
+  }
+
+  .select {
+    margin-bottom: var(--spacing-huge);
+  }
+
+  .table {
+    margin: auto;
+    max-width: 1200px;
   }
 }

--- a/frontend/src/views/Recruitment/ProcessDetail/ProcessDetail.module.scss
+++ b/frontend/src/views/Recruitment/ProcessDetail/ProcessDetail.module.scss
@@ -1,0 +1,39 @@
+@import "~styles/breakpoints";
+
+.container {
+  text-align: center;
+
+  .button {
+    margin-bottom: var(--spacing-large);
+  }
+
+  .title {
+    margin-bottom: var(--spacing-huge);
+    h1 {
+      color: var(--gray-dark);
+    }
+  }
+
+  .dates {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    .date {
+      margin: var(--spacing-base) 0;
+
+      @include tablet-portrait {
+        margin: 0 var(--spacing-huge);
+      }
+
+      span {
+        color: var(--gray-dark);
+      }
+    }
+
+    @include tablet-portrait {
+      flex-direction: row;
+      justify-content: center;
+    }
+  }
+}

--- a/frontend/src/views/Recruitment/ProcessDetail/ProcessDetail.module.scss
+++ b/frontend/src/views/Recruitment/ProcessDetail/ProcessDetail.module.scss
@@ -40,6 +40,13 @@
 
   .select {
     margin-bottom: var(--spacing-huge);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    &__info {
+      margin-left: var(--spacing-base);
+    }
   }
 
   .table {

--- a/frontend/src/views/Recruitment/ProcessDetail/columns.js
+++ b/frontend/src/views/Recruitment/ProcessDetail/columns.js
@@ -1,0 +1,45 @@
+import React from "react";
+
+import { Popover, Tag } from "antd";
+import { QuestionCircleOutlined } from "@ant-design/icons";
+
+import popover from "./popover";
+
+const columns = [
+  {
+    title: "Evento",
+    dataIndex: "summary",
+    key: "name",
+  },
+  {
+    title: "Início",
+    dataIndex: ["start", "dateTime"],
+    key: "start",
+    render: value => value ? new Date(value).toTimeString().slice(0, 5) : "-"
+  },
+  {
+    title: "Fim",
+    dataIndex: ["end", "dateTime"],
+    key: "end",
+    render: value => value ? new Date(value).toTimeString().slice(0, 5) : "-"
+  },
+  {
+    title: <div>
+      <span style={{ marginRight: `15px` }}>Status</span>
+      <Popover placement="top" content={popover}>
+        <QuestionCircleOutlined />
+      </Popover>
+    </div>,
+    dataIndex: "processStatus",
+    key: "status",
+    render: value => <Tag color={value.color}>{value.status}</Tag>
+  },
+  {
+    title: "Meet",
+    dataIndex: "hangoutLink",
+    key: "hangoutLink",
+    render: value => value ? <a href={value} target="_blank">Link</a> : "-"
+  },
+];
+
+export default columns;

--- a/frontend/src/views/Recruitment/ProcessDetail/popover.js
+++ b/frontend/src/views/Recruitment/ProcessDetail/popover.js
@@ -1,0 +1,26 @@
+import React from "react";
+
+import { Tag } from "antd";
+
+const style = {
+  margin: `10px 0`,
+}
+
+const popover = (
+  <div style={{ maxWidth: `280px` }}>
+    <div style={style}>
+      <Tag color="orange">Vago</Tag>
+      Significa que ninguém ainda está alocado para o evento
+      </div>
+    <div style={style}>
+      <Tag color="blue">Pendente</Tag>
+      Significa que um candidato escolheu este horário mas não confirmou presença no evento ainda
+      </div>
+    <div style={style}>
+      <Tag color="green">Confirmado</Tag>
+      Significa que o candidato já confirmou a presença no evento!
+      </div>
+  </div>
+);
+
+export default popover;

--- a/frontend/src/views/Recruitment/Recruitment.js
+++ b/frontend/src/views/Recruitment/Recruitment.js
@@ -59,13 +59,13 @@ const Recruitment = ({ history }) => {
     }
   };
 
-  const actions = [
+  const actions = (name) => [
     <Tooltip placement="left" title="Detalhe">
-      <InfoCircleOutlined onClick={() => alert("info")} />
+      <InfoCircleOutlined onClick={() => history.push(routes.PROCESS_DETAIL.replace(":name", name))} />
     </Tooltip>
   ];
 
-  const activeActions = (name) => [...actions,
+  const activeActions = (name) => [...actions(name),
   <Tooltip placement="bottom" title="Editar">
     <EditOutlined
       key="edit"
@@ -107,7 +107,6 @@ const Recruitment = ({ history }) => {
       <PageTitle title="Recrutamento" />
       <Container>
         <div className={styles.recruitment}>
-          { }
           <div className={styles.buttons}>
             <Button
               icon={<ArrowLeftOutlined />}
@@ -144,7 +143,7 @@ const Recruitment = ({ history }) => {
                     actions={
                       proc.status === "active" ?
                         activeActions(proc.name) :
-                        actions
+                        actions(proc.name)
                     }
                   >
                     <div style={{ display: "flex", justifyContent: "space-evenly" }}>

--- a/frontend/src/views/Recruitment/Recruitment.js
+++ b/frontend/src/views/Recruitment/Recruitment.js
@@ -137,7 +137,7 @@ const Recruitment = ({ history }) => {
               </div>
             ) : (listAll ? processes : activeProcesses).map((proc) => {
               return (
-                <div className={styles.card}>
+                <div className={styles.card} key={proc.id}>
                   <Card
                     style={{ width: 300, textAlign: "center" }}
                     actions={


### PR DESCRIPTION
## Tipo da mudança

- [x] Nova feature

# Descrição

Resolve #107 

- Adiciona e integra a tela de detalhe de um processo de recrutamento
- Adiciona alguns helpers para modificar os dados que vem da API do Google Calendar (status e separação dos eventos por dia)

![image](https://user-images.githubusercontent.com/32711358/107296790-d77aa880-6a50-11eb-86fe-947433201430.png)

# Como foi testado?

- Simular o fluxo de criação do PS (seguido da criação dos eventos no Google Calendar) e visualização do detalhe
- Foram adicionados testes unitários para as funções em `backend/src/calendar/helpers`

# Checklist:

- [x] Fiz uma revisão própria do código
- [x] Adicionei testes que provam que a feature/mudança funciona
- [x] Testes novos e existentes ainda passam com esta mudança
